### PR TITLE
Add mysql config directory parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,7 @@ class galera (
   $cluster_name                = 'galera',
   $package_name                = 'galera',
   $mysql_bind_address          = '0.0.0.0',
+  $mysql_config_directory      = '/etc/mysql/conf.d/',
   $wsrep_provider              = '/usr/lib/galera/libgalera_smm.so',
   $wsrep_provider_options      = '',
   $wsrep_node_name             = $::hostname,
@@ -51,10 +52,10 @@ class galera (
   package { 'galera':
     ensure  => present,
     name    => $package_name,
-    require => Package['mysql_client'],
+    #require => Package['mysql_client'],
   }
 
-  file { '/etc/mysql/conf.d/wsrep.cnf':
+  file { "${mysql_config_directory}/wsrep.cnf":
     ensure  => present,
     content => template('galera/wsrep.cnf.erb'),
     require => Package['galera'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,7 +52,6 @@ class galera (
   package { 'galera':
     ensure  => present,
     name    => $package_name,
-    #require => Package['mysql_client'],
   }
 
   file { "${mysql_config_directory}/wsrep.cnf":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,6 +52,7 @@ class galera (
   package { 'galera':
     ensure  => present,
     name    => $package_name,
+    require => Package['mysql-server'],  
   }
 
   file { "${mysql_config_directory}/wsrep.cnf":


### PR DESCRIPTION
For some reason does the mysql-client package dependancy on package['galera] cause a dependancy loop here. I think it's more logical to depend on the mysql-server package
